### PR TITLE
Fix critical bug where training ignores .pt init checkpoints

### DIFF
--- a/cosmos_policy/scripts/train.py
+++ b/cosmos_policy/scripts/train.py
@@ -34,6 +34,7 @@ from cosmos_policy._src.imaginaire.serialization import to_yaml
 from cosmos_policy._src.imaginaire.utils import distributed
 from cosmos_policy._src.imaginaire.utils.context_managers import data_loader_init, distributed_init, model_init
 from cosmos_policy._src.imaginaire.utils.launch import log_reproducible_setup
+from cosmos_policy._src.predict2.utils.model_loader import create_model_from_consolidated_checkpoint_with_fsdp
 
 
 @logging.catch(reraise=True)
@@ -53,7 +54,11 @@ def launch(config: Config, args: argparse.Namespace) -> None:
     log_reproducible_setup(config, args)
 
     with model_init():
-        model = instantiate(config.model)
+        if config.checkpoint.load_path and str(config.checkpoint.load_path).endswith(".pt"):
+            logging.info(f"Loading model weights from consolidated checkpoint: {config.checkpoint.load_path}")
+            model = create_model_from_consolidated_checkpoint_with_fsdp(config)
+        else:
+            model = instantiate(config.model)
 
     # Create the dataloaders.
     with data_loader_init():


### PR DESCRIPTION
This PR fixes a bug where experiments configured with a .pt `checkpoint.load_path`  https://github.com/NVlabs/cosmos-policy/blob/18a2accadf4e7a3531e56754102af5a24d2316da/cosmos_policy/config/experiment/cosmos_policy_experiment_configs.py#L148

 would **start from scratch** instead of loading the checkpoint.

Before: `Resuming ckpt None with keys: []` and then `Training from scratch`
After: `Loading model weights from consolidated checkpoint: ...model-480p-16fps.pt`

I also reproduced the issue with RoboCasa with 2H100, grad acc 4, 100 steps. The loss values differ significantly:
step 1: 12.4104 (before) => 2.7763 (after)
step 100: 2.6203 => 0.6255

This addresses #8 and possibly #7.